### PR TITLE
[modify] #46: 상세페이지 코스 선택 시 보여지는 화면 수정

### DIFF
--- a/src/main/webapp/board/boardDetail.jsp
+++ b/src/main/webapp/board/boardDetail.jsp
@@ -54,8 +54,21 @@
 							int contentCount = postDAO.getContentCount(postId); 
 							for(int i=0; i<contentCount; i++) {
 						%>
-							<li onclick="showCourseDetail(this)">
-								<img src="<%= IMG_PATH %>/<%= URLEncoder.encode(images.get(i), "UTF-8") %>" />
+								<% if(i==0) { %>
+								<li class="course-list course-on-half" onclick="showCourseDetail(this)">
+									<strong class="course-number active-course-number"><%= i+1 %></strong>
+									<div class="course-image-wrap active-course-image">
+										<figure class="course-image" style="background:url(<%= IMG_PATH %>/<%= URLEncoder.encode(images.get(i), "UTF-8") %>); 
+										background-size: contain; background-repeat: no-repeat; background-position: 50% 50%;"></figure>															
+									</div>
+								<% } else { %>
+							<li class="course-list" onclick="showCourseDetail(this)">
+								<strong class="course-number"><%= i+1 %></strong>
+								<div class="course-image-wrap">
+									<figure class="course-image" style="background:url(<%= IMG_PATH %>/<%= URLEncoder.encode(images.get(i), "UTF-8") %>); 
+									background-size: contain; background-repeat: no-repeat; background-position: 50% 50%;"></figure>															
+								</div>
+								<% } %>
 								<h1 class="course-image-title"><%= contentTitles.get(i) %></h1>
 								<div class="course-info" 
 						             data-title="<%= contentTitles.get(i) %>" 

--- a/src/main/webapp/resources/css/boardDetail.css
+++ b/src/main/webapp/resources/css/boardDetail.css
@@ -3,11 +3,15 @@
 .contents {
 	width: 88%;
 	margin: auto;
+	border-radius: 7px;
+    border: 2px solid #1d78e252;
 }
 
 .content-wrap {
 	width: 100%;
 	margin: auto;	
+	padding: 5px;
+    box-sizing: border-box;
 }
 
 #content-title {
@@ -15,49 +19,123 @@
 	text-align: center;
 }
 
+.content::before {
+	content: '';
+    display: block;
+    width: 100%;
+    position: absolute;
+    top: 24px;
+    border: 2px dashed #f3f2f2;
+    z-index: -2;
+}
+
 .content {
     display: flex;
     flex-direction: column;
     overflow: hidden;
     position: relative;
+    margin-bottom: 40px;
 }
+
 
 .course-lists {
 	display: flex;
 	list-style: none;
-	padding: 0;
+	padding: 10px;
     margin: 0 auto;
     transition: transform 0.5s ease;
 }
 
 .course-lists li {
-	width: 180px;
-	height: 180px;
+	width: 20vw;
+	height: 25.2vw;
 	margin: 0 15px;
 	cursor: pointer;
 	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
-.course-lists li > img {
-	width: 100%;
-	height: 100%;
-	border-radius: 10px;
-	box-shadow: 2px 2px 10px 0px rgba(150,149,149,1);
+.course-on-half::before {
+	content: '';
+    display: block;
+    width: 65%;
+    height: 4px;
+    background: #ed4956;
+    position: absolute;
+    left: -27px;
+    top: 14px;
+    z-index: -1;
 }
 
-.course-lists li > img::after {
-	background: grey;
+.course-on-full::before {
+	content: '';
+    display: block;
+    width: 130%;
+    height: 4px;
+    background: #ed4956;
+    position: absolute;
+    left: -27px;
+    top: 14px;
+    z-index: -1;
+}
+
+.course-number {
+	width: 30px;
+	height: 30px;
+	margin-bottom: 5px;
+	text-align: center;
+	line-height: 30px;
+	border: 2px solid #bfbfbf;
+	border-radius: 100%;
+	background-color: white;
+	color: #767676;
 }
 
 .course-image-title {
 	position: absolute;
-	top: 33%;
+	top: 40%;
 	width: 95%;
 	text-align: center;
+	font-size: 1.3rem;
 	padding: 0 5px;
 	color: white;
 	word-break: break-all;
 	overflow-wrap: break-word;
+}
+
+.course-image-wrap {
+    width: 100%;
+    height: 100%;
+}
+
+.course-image {
+	margin: 0;
+	width: 100%;
+	height: 100%;
+	border-radius: 10px;
+}
+
+.course-image::after {
+	content: '';
+	display: block;
+	background-color: rgba(0, 0, 0, 0.05);
+	border-radius: 10px;
+	width: 100%;
+	height: 100%;
+}
+
+.course-image-wrap:hover, .active-course-image {
+	background-color: #33cad257;
+	border-radius: 10px;
+	box-shadow: 2px 2px 10px 0px rgba(150,149,149,1);
+}
+
+.active-course-number {
+	background-color: white;
+	border: 2px solid #024a9f;
+	color: #024a9f;
 }
 
 .profile, .reply-profile {
@@ -113,7 +191,7 @@
 	height: 30px;
 	position: absolute;
 	cursor: pointer;
-	top: 50%;
+	top: 56%;
 	transform: translateY(-50%);
 }
 
@@ -123,17 +201,16 @@
 	height: 30px;
 	position: absolute;
 	cursor: pointer;
-	top: 50%;
+	top: 56%;
 	right: 0;
 	transform: translateY(-50%);
 }
 
 .course-detail {
-	margin: 50px auto;
+	margin: 10px;
 	padding: 5px 10px;
-	border: lightsteelblue solid 1px;
 	border-radius: 7px;
-	box-shadow: 2px 2px 10px 0px rgba(150,149,149,1);
+	box-shadow: 1px 1px 6px 0px #33cad2;
 	word-break: break-all;
 	overflow-wrap: break-word;
 }

--- a/src/main/webapp/resources/js/boardDetail.js
+++ b/src/main/webapp/resources/js/boardDetail.js
@@ -37,6 +37,29 @@ const confirmSubmission = () => {
 
 // Show course details when the course image is clicked
 const showCourseDetail = (element) => {
+	// 클릭된 코스 이미지의 배경과 숫자를 선택
+    document.querySelectorAll('.course-image-wrap').forEach(li => li.classList.remove('active-course-image'));
+    document.querySelectorAll('.course-number').forEach(li => li.classList.remove('active-course-number'));
+
+    element.querySelector('.course-image-wrap').classList.add('active-course-image');
+    element.querySelector('.course-number').classList.add('active-course-number');
+    
+    // 클릭된 코스 숫자의 진행도 나타내는 선
+    const allLiElements = document.querySelectorAll('.course-lists .course-list');
+        
+    allLiElements.forEach(li => {
+        li.classList.remove('course-on-half', 'course-on-full');
+    });
+
+    const index = Array.from(allLiElements).indexOf(element);
+
+    element.classList.add('course-on-half');
+
+    for (let i = 0; i < index; i++) {
+        allLiElements[i].classList.add('course-on-full');
+    }
+    
+    // 선택된 코스의 상세 정보를 나타내줌
     const courseDetailTitle = document.getElementById("course-detail-title");
     const courseDetailLocation = document.getElementById("course-detail-location");
     const courseDetailImage = document.getElementById("course-detail-image");


### PR DESCRIPTION
### ✨ 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
상세페이지 코스 이미지 선택 시, 선택된 코스 포커싱되는 효과가 보이게 수정.
그에 따른 img 태그 대신 div>figure 태그의 background-image를 사용.
상세페이지 디자인 수정

### 🙋🏻 PR 타입(하나 이상의 PR 타입을 선택해주세요)
어떤 변경 사항이 있나요?

- [x] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [x] CSS 등 사용자 UI 디자인 변경 🎨
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) ✏️
- [x] 코드 형태 개선 🎨
- [ ] 주석 추가 및 수정 ✏️
- [ ] 문서 수정 📝
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨
- [ ] 파일 혹은 폴더명 수정 📂
- [ ] 파일 혹은 폴더 삭제 🗑️


### 📷 Key Changes
<!-- 구현 내용 중 애니메이션이나 화면 UI와 관련된 내용이 있을때 넣을 수 있다면 넣어주세요. -->
<img width="744" alt="image" src="https://github.com/DevDanielNAM/BFC/assets/108088887/29f80a78-375b-41a7-b009-6706aa27b04c">


### ✍🏻 To Reviewers
<!-- 팀원들에게 코드리뷰를 할 때 확인해주었으면 하는 내용을 적어주세요. -->
<!-- 여기에서 이 부분 잘 모르겠는데 한번 봐주실 수 있나요? -->
